### PR TITLE
Add AAR type (boom/probe) for refueling over MP

### DIFF
--- a/aircraft/F-15/Models/f15c.xml
+++ b/aircraft/F-15/Models/f15c.xml
@@ -14,6 +14,7 @@
             <offset-x-m type="double">-0.3457</offset-x-m>
             <offset-y-m type="double">-1.6912</offset-y-m>
             <offset-z-m type="double">0.7946</offset-z-m>
+            <type type="string">boom</type>
         </refuel>
     </multiplay>
 

--- a/aircraft/f-14b/Models/f-14b.xml
+++ b/aircraft/f-14b/Models/f-14b.xml
@@ -8,6 +8,7 @@
             <offset-x-m type="double">-7.1969</offset-x-m>
             <offset-y-m type="double">1.0409</offset-y-m>
             <offset-z-m type="double">0.0387</offset-z-m>
+            <type type="string">probe</type>
         </refuel>
     </multiplay>
 


### PR DESCRIPTION
This patch makes the F-15 and F-14 compatible again with the 707 tanker, which was modified so that drogues will not attempt to track aircraft with a receptacle and the boom will not try to track aircraft with a probe.

Fixes #37
